### PR TITLE
introduce a dynamic node inactivity timer variable

### DIFF
--- a/api/src/vars.ts
+++ b/api/src/vars.ts
@@ -24,6 +24,7 @@ export let automaticTraceroutes = new State<boolean>('automaticTraceroutes', tru
 
 /** Measured in minutes */
 export let tracerouteRateLimit = new State<number>('tracerouteRateLimit', 15, { persist: true })
+export let nodeInactiveTimer = new State<number>('nodeInactiveTimer', 60, { persist: true })
 
 export type DeviceMetadata = {
   firmwareVersion: string

--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -22,7 +22,7 @@
   $: if ($nodes.length) showInactive, filterNodes()
 
   function filterNodes() {
-    $inactiveNodes = $nodes.filter((node) => Date.now() - node.lastHeard * 1000 >= 3.6e6)
+    $inactiveNodes = $nodes.filter((node) => Date.now() - node.lastHeard * 1000 >= $nodeInactiveTimer * 60 * 1000)
 
     $filteredNodes = $nodes
       .filter((node) => showInactive || !$inactiveNodes.some((inactive) => node.num == inactive.num))


### PR DESCRIPTION
This should be considered a start for introducing a new global variable $nodeInactiveTimer to modify the threshold of what is considered inactive nodes per feature request #3.  Feel free to change the variable name to better match a defined naming scheme.

New code is still needed to interact with the user to set this variable value in settings, or in a new selectable 30, 60, 90, 120 minutes dropdown.  I do not know how to code that component.