### PR TITLE
display reported channel utilization %

### DIFF
--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -130,6 +130,12 @@
                 {node.rssi || '-'}
               </div>
             {/if}
+            <!-- Channel Utilization % -->
+            {#if node.deviceMetrics?.channelUtilization}
+              <div class="text-sm w-10 shrink-0 text-center bg-black/20 rounded h-5">
+                {(node.deviceMetrics?.channelUtilization).toFixed(0)}%ch
+              </div>
+            {/if}
           </div>
 
           <div class="flex gap-1.5 items-center">

--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -131,15 +131,35 @@
               </div>
             {/if}
             <!-- Channel Utilization % -->
-            {#if node.deviceMetrics?.channelUtilization}
-              {let $thisNodeChUasINT    = Math.floor(node.deviceMetrics?.channelUtilization);
-               let $thisNodeChUcolorbar = ($thisNodeChUasINT < 15 ? 'green' : $thisNodeChUasINT < 25 ? 'yellow' : 'red')}
-              <div title="{$thisNodeChUasINT}% Channel Utilization"
-                class="absolute w-1.5 rounded bottom-1 top-1 right-0.5 overflow-hidden border border-white/20 flex flex-col"
-              >
-                <div class="grow"></div>
-                <div class="bg-green-500" style="height: {$thisNodeChUasINT}%;"></div>
-              </div>
+            {#if node?.deviceMetrics?.channelUtilization}
+              {#let channelUtilizationINT = Math.floor(node.deviceMetrics.channelUtilization)}
+                {#let scaledHeight = Math.min(channelUtilizationINT * 2, 100)}
+                {#let colorClass = 
+                  channelUtilizationINT < 15 ? 'green' : 
+                  channelUtilizationINT < 25 ? 'yellow' : 
+                  channelUtilizationINT < 35 ? 'orange' : 
+                  'red'
+                }
+                  <div 
+                    title="{channelUtilizationINT}% Observed Channel Utilization"
+                    class="absolute w-1.5 rounded bottom-1 top-1 right-0.5 overflow-hidden border border-white/20 flex flex-col"
+                    aria-label="Observed Channel Utilization: {channelUtilizationINT}%"
+                    aria-valuemin="0"
+                    aria-valuemax="50"
+                    aria-valuenow={channelUtilizationINT}
+                  >
+                    <div class="grow"></div>
+                    <div 
+                      class:bg-green-500={colorClass === 'green'}
+                      class:bg-yellow-500={colorClass === 'yellow'}
+                      class:bg-orange-500={colorClass === 'orange'}
+                      class:bg-red-500={colorClass === 'red'}
+                      style="height: {scaledHeight}%;"
+                    ></div>
+                  </div>
+                {/let}
+                {/let}
+              {/let}
             {/if}
           </div>
 

--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -132,8 +132,13 @@
             {/if}
             <!-- Channel Utilization % -->
             {#if node.deviceMetrics?.channelUtilization}
-              <div class="text-sm w-10 shrink-0 text-center bg-black/20 rounded h-5">
-                {(node.deviceMetrics?.channelUtilization).toFixed(0)}%ch
+              {let $thisNodeChUasINT    = Math.floor(node.deviceMetrics?.channelUtilization);
+               let $thisNodeChUcolorbar = ($thisNodeChUasINT < 15 ? 'green' : $thisNodeChUasINT < 25 ? 'yellow' : 'red')}
+              <div title="{$thisNodeChUasINT}% Channel Utilization"
+                class="absolute w-1.5 rounded bottom-1 top-1 right-0.5 overflow-hidden border border-white/20 flex flex-col"
+              >
+                <div class="grow"></div>
+                <div class="bg-green-500" style="height: {$thisNodeChUasINT}%;"></div>
               </div>
             {/if}
           </div>


### PR DESCRIPTION
Proposed Enhancement: will display reported channel utilization% (rounded to int) for each node. Placement to the right of any reported SNR and RSSI

Users may find each node's respective reported channel utilization useful in identifying problem areas on the mesh.  For now, I think the best placement for this is to the right of any potential reported SNR and RSSI data.  The box will only display if deviceMetrics?.channelUtilization exists, displaying only an INT value.

Eventually we could have a toggle in settings to display this or not.  We could also later add a colorized bar below the value once defined thresholds have been set. (0-14 green, 15-24 yellow, 25+ red ?)

proposed rough illustration:
![image](https://github.com/user-attachments/assets/2df90804-179b-4421-86c5-0523238182e9)

*** Please give feedback or correct the html class used here.  I used w-10 but perhaps w-8 or some other value is more appropriate?