### PR TITLE
fix UI grayscale for inactive node timer

### DIFF
--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -81,7 +81,7 @@
     {#each $filteredNodes as node (node.num)}
       <div
         class:ring-1={node.hopsAway == 0}
-        class="bg-blue-300/10 rounded px-1 py-0.5 flex flex-col gap-0.5 {node.num == $myNodeNum ? 'bg-gradient-to-r ' : ''}  {Date.now() - node.lastHeard * 1000 < 3.6e6 ? '' : 'grayscale'}"
+        class="bg-blue-300/10 rounded px-1 py-0.5 flex flex-col gap-0.5 {node.num == $myNodeNum ? 'bg-gradient-to-r ' : ''}  {Date.now() - node.lastHeard * 1000 < (($nodeInactiveTimer ?? 60) * 60 * 1000) ? '' : 'grayscale'}"
       >
         {#if $smallMode}
           <div title={node.user?.longName} class="flex items-center gap-1">


### PR DESCRIPTION
A static 1 hr timer for colorization was overlooked when adding the new user-defined inactive timer. Now the node will remain colorized while considered active.