### PR TITLE
added case for 101% battery / external power

### DIFF
--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -152,14 +152,17 @@
             </div>
             <!-- Battery -->
             <div class="text-sm font-normal bg-black/20 rounded p-1 min-w-11 h-7 text-center">
-              {node.deviceMetrics?.batteryLevel || 0}%
+              {#if node.deviceMetrics?.batteryLevel === 101 // device using external power}
+                🔌
+              {:else}
+                {node.deviceMetrics?.batteryLevel || 0}%
+              {/if}
               <div
                 class="h-0.5"
-                style="width: {node.deviceMetrics?.batteryLevel || 0}%; background-color: {node.deviceMetrics?.batteryLevel >= 70
-                  ? 'green'
-                  : node.deviceMetrics?.batteryLevel >= 30
-                    ? 'yellow'
-                    : 'red'};"
+                style="width: {node.deviceMetrics?.batteryLevel || 0}%; background-color: {node.deviceMetrics?.batteryLevel === 101 ? 'steelblue'
+                  : node.deviceMetrics?.batteryLevel >= 70 ? 'green'
+                  : node.deviceMetrics?.batteryLevel >= 30 ? 'yellow'
+                  : 'red'};"
               ></div>
             </div>
 

--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -152,7 +152,8 @@
             </div>
             <!-- Battery -->
             <div class="text-sm font-normal bg-black/20 rounded p-1 min-w-11 h-7 text-center">
-              {#if node.deviceMetrics?.batteryLevel === 101 // device using external power}
+              {#if node.deviceMetrics?.batteryLevel === 101}
+                <!-- device using external power -->
                 ⚡︎
               {:else}
                 {node.deviceMetrics?.batteryLevel || 0}%

--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -153,7 +153,7 @@
             <!-- Battery -->
             <div class="text-sm font-normal bg-black/20 rounded p-1 min-w-11 h-7 text-center">
               {#if node.deviceMetrics?.batteryLevel === 101 // device using external power}
-                🔌
+                ⚡︎
               {:else}
                 {node.deviceMetrics?.batteryLevel || 0}%
               {/if}


### PR DESCRIPTION
Instead of reporting battery usage of 101%, display a 🔌 icon and change colorbar representation to SteelBlue

This should satisfy issue #15 