### PR TITLE
Post received event prior to triggering traceroute

### DIFF
--- a/api/src/meshtastic.ts
+++ b/api/src/meshtastic.ts
@@ -250,6 +250,7 @@ export async function connect(address?: string) {
         })
       }
 
+      packets.push(copy(e))
       let originalNodeRecord = nodes.value.find((n) => n.num == updates.num)
       if (updates.hopsAway == 0) updates.trace = null
       else if (automaticTraceroutes.value && originalNodeRecord?.position?.latitudeI && updates.hopsAway && (!originalNodeRecord.trace || originalNodeRecord?.hopsAway != updates.hopsAway)) {
@@ -258,7 +259,6 @@ export async function connect(address?: string) {
 
       // console.log(updates)
       nodes.upsert(updates)
-      packets.push(copy(e))
     }
   })
 


### PR DESCRIPTION
Issue:
When meshsense decides to perform a traceroute in response to receiving an event from a node, it will wait to publish the origin event until after it triggers sending a traceroute. This leads to a race condition where the traceroute event is often times published to the log prior to the original event, leading to some confusion.

Fix:
This change always posts the origin event prior to triggering a traceroute.

Testing:
This change was tested by running locally and observing the desired result over the course of several triggered traceroutes.

Fixes #39 