### PR TITLE
Update README.md for proper webbluetooth path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd MeshSense
 Build `webbluetooth`
 
 ```
-cd webbluetooth
+cd api/webbluetooth
 npm i
 npm run build:all
 ```


### PR DESCRIPTION
The webbluetooth submodule is wtihin the api folder, so I updated the docs to reflect that.