### PR TITLE
Channel Utilization % vertical colorized bar

### DIFF
--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -124,7 +124,7 @@
             <img class="h-4 inline-block" src="https://icongaga-api.bytedancer.workers.dev/api/genHexer?name={node.num}" alt="Node {node.user?.id}" />
 
             <div class="relative w-2 h-6">
-              <!-- Channel Utilization for longMode -->
+              <!-- Channel Utilization for largeMode -->
               <ChannelUtilization {node} />
             </div>
 

--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -83,7 +83,7 @@
     {#each $filteredNodes as node (node.num)}
       <div
         class:ring-1={node.hopsAway == 0}
-        class="relative bg-blue-300/10 rounded px-1 py-0.5 flex flex-col gap-0.5 {node.num == $myNodeNum
+        class="bg-blue-300/10 rounded px-1 py-0.5 flex flex-col gap-0.5 {node.num == $myNodeNum
           ? 'bg-gradient-to-r '
           : Date.now() - node.lastHeard * 1000 < ($nodeInactiveTimer ?? 60) * 60 * 1000
             ? ''
@@ -92,6 +92,12 @@
         {#if $smallMode}
           <div title={node.user?.longName} class="flex items-center gap-1">
             <img class="h-4 inline-block" src="https://icongaga-api.bytedancer.workers.dev/api/genHexer?name={node.num}" alt="Node {node.user?.id}" />
+
+            <div class="relative w-2 h-6">
+              <!-- Channel Utilization for smallMode -->
+              <ChannelUtilization {node} />
+            </div>
+
             <!-- Shortname -->
             <button on:click={() => ($messageDestination = node.num)} class="bg-black/20 rounded w-12 text-center overflow-hidden">{node.user?.shortName || '?'}</button>
 
@@ -111,17 +117,20 @@
               <div title="{node.hopsAway} Hops Away" class="text-sm font-normal bg-black/20 rounded w-10 text-center">{node.num == $myNodeNum ? '-' : (node.hopsAway ?? '?')}</div>
             {/if}
 
-            <!-- Channel Utilization for smallMode -->
-            <ChannelUtilization {node} />
           </div>
         {:else}
           <!-- Longname -->
           <div class="flex gap-1 items-center">
             <img class="h-4 inline-block" src="https://icongaga-api.bytedancer.workers.dev/api/genHexer?name={node.num}" alt="Node {node.user?.id}" />
 
+            <div class="relative w-2 h-6">
+              <!-- Channel Utilization for longMode -->
+              <ChannelUtilization {node} />
+            </div>
+
             <button title={node.user?.longName || '!' + node.num?.toString(16)} class="text-left truncate max-w-44" on:click={() => ($messageDestination = node.num)}
-              >{node.user?.longName || '!' + node.num?.toString(16)}</button
-            >
+              >{node.user?.longName || '!' + node.num?.toString(16)}</button>
+
             {#if node.user?.role != undefined}
               {#if node.user.role === 0}
                 <div title="Client Node" class="bg-blue-500/50 rounded px-1 font-bold cursor-help">C</div>
@@ -250,9 +259,6 @@
               </button>
             {/if}
           </div>
-
-          <!-- Channel Utilization for normal mode -->
-          <ChannelUtilization {node} />
 
           {#if node.environmentMetrics}
             <div class="flex gap-1">

--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -15,6 +15,7 @@
   import OpenLayersMap from './lib/OpenLayersMap.svelte'
   import { messageDestination } from './Message.svelte'
   import { setPositionMode } from './Map.svelte'
+  import ChannelUtilization from './lib/ChannelUtilization.svelte'
 
   export let showInactive = false
   let selectedNode: NodeInfo
@@ -109,6 +110,9 @@
               <!-- Hops -->
               <div title="{node.hopsAway} Hops Away" class="text-sm font-normal bg-black/20 rounded w-10 text-center">{node.num == $myNodeNum ? '-' : (node.hopsAway ?? '?')}</div>
             {/if}
+
+            <!-- Channel Utilization for smallMode -->
+            <ChannelUtilization {node} />
           </div>
         {:else}
           <!-- Longname -->
@@ -246,6 +250,10 @@
               </button>
             {/if}
           </div>
+
+          <!-- Channel Utilization for normal mode -->
+          <ChannelUtilization {node} />
+
           {#if node.environmentMetrics}
             <div class="flex gap-1">
               {#if node.environmentMetrics.temperature}

--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -83,7 +83,7 @@
     {#each $filteredNodes as node (node.num)}
       <div
         class:ring-1={node.hopsAway == 0}
-        class="bg-blue-300/10 rounded px-1 py-0.5 flex flex-col gap-0.5 {node.num == $myNodeNum
+        class="relative bg-blue-300/10 rounded px-1 py-0.5 flex flex-col gap-0.5 {node.num == $myNodeNum
           ? 'bg-gradient-to-r '
           : Date.now() - node.lastHeard * 1000 < ($nodeInactiveTimer ?? 60) * 60 * 1000
             ? ''

--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -90,6 +90,7 @@
             : 'grayscale'}  "
       >
         {#if $smallMode}
+          <!-- Short Mode -->
           <div title={node.user?.longName} class="flex items-center gap-1">
             <img class="h-4 inline-block" src="https://icongaga-api.bytedancer.workers.dev/api/genHexer?name={node.num}" alt="Node {node.user?.id}" />
 
@@ -119,7 +120,7 @@
 
           </div>
         {:else}
-          <!-- Longname -->
+          <!-- Large Mode -->
           <div class="flex gap-1 items-center">
             <img class="h-4 inline-block" src="https://icongaga-api.bytedancer.workers.dev/api/genHexer?name={node.num}" alt="Node {node.user?.id}" />
 
@@ -128,6 +129,7 @@
               <ChannelUtilization {node} />
             </div>
 
+            <!-- Longname -->
             <button title={node.user?.longName || '!' + node.num?.toString(16)} class="text-left truncate max-w-44" on:click={() => ($messageDestination = node.num)}
               >{node.user?.longName || '!' + node.num?.toString(16)}</button>
 

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -89,3 +89,12 @@ button:active {
 .label {
   @apply select-none;
 }
+
+/* Added custom color classes for vertical bars (e.g. channel utilization) */
+.bg-yellow-500 {
+  background-color: #eab308;
+}
+
+.bg-orange-500 {
+  background-color: #f97316;
+}

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -91,10 +91,31 @@ button:active {
 }
 
 /* Added custom color classes for vertical bars (e.g. channel utilization) */
-.bg-yellow-500 {
-  background-color: #eab308;
+
+/* inherited from tailwind
+.bg-green-500 {
+  background-color: inherited;
+} */
+
+.bg-greenyellow-500 {
+  background-color: #9acd32;
 }
 
+/* inherited from tailwind
+.bg-yellow-500 {
+  background-color: inherited;
+} */
+
+/* inherited from tailwind
 .bg-orange-500 {
-  background-color: #f97316;
+  background-color: inherited;
+} */
+
+/* inherited from tailwind 
+.bg-red-500 {
+  background-color: inherited;
+} */
+
+.bg-superred-500 {
+  background-color: red;
 }

--- a/ui/src/lib/ChannelUtilization.svelte
+++ b/ui/src/lib/ChannelUtilization.svelte
@@ -12,9 +12,11 @@
  
   $: colorClass = channelUtilizationINT !== null
     ? (channelUtilizationINT < 15 ? 'green' : 
+       channelUtilizationINT < 20 ? 'greenyellow' :
        channelUtilizationINT < 25 ? 'yellow' : 
-       channelUtilizationINT < 35 ? 'orange' : 
-       'red')
+       channelUtilizationINT < 30 ? 'orange' : 
+       channelUtilizationINT < 35 ? 'red' :
+       'superred')
     : 'grayscale'; // default color when channelUtilizationINT is null
 </script>
  
@@ -29,9 +31,11 @@
   <div class="grow"></div>
   <div
     class:bg-green-500={colorClass === 'green'}
+    class:bg-greenyellow-500={colorClass === 'greenyellow'}
     class:bg-yellow-500={colorClass === 'yellow'}
     class:bg-orange-500={colorClass === 'orange'}
     class:bg-red-500={colorClass === 'red'}
+    class:bg-superred-500={colorClass === 'superred'}
     class:bg-gray-500={colorClass === 'grayscale'}
     style="height: {scaledHeight}%;"
   ></div>

--- a/ui/src/lib/ChannelUtilization.svelte
+++ b/ui/src/lib/ChannelUtilization.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import type { NodeInfo } from 'api/src/vars';
+  export let node: NodeInfo;
+ 
+  $: channelUtilizationINT = node?.deviceMetrics?.channelUtilization 
+    ? Math.floor(node.deviceMetrics.channelUtilization) 
+    : null;
+ 
+  $: scaledHeight = channelUtilizationINT !== null 
+    ? Math.min(channelUtilizationINT * 2, 100) 
+    : 0;
+ 
+  $: colorClass = channelUtilizationINT !== null
+    ? (channelUtilizationINT < 15 ? 'green' : 
+       channelUtilizationINT < 25 ? 'yellow' : 
+       channelUtilizationINT < 35 ? 'orange' : 
+       'red')
+    : 'grayscale'; // default color when channelUtilizationINT is null
+</script>
+ 
+<div
+  title="{channelUtilizationINT !== null ? channelUtilizationINT + '% Observed Channel Utilization' : 'Channel Utilization Not Reported'}"
+  class="absolute w-1.5 rounded bottom-1 top-1 right-0.5 overflow-hidden border border-white/20 flex flex-col"
+  aria-label="{channelUtilizationINT !== null ? 'Observed Channel Utilization: ' + channelUtilizationINT + '%' : 'Channel Utilization Not Reported'}"
+  aria-valuemin="0"
+  aria-valuemax="50"
+  aria-valuenow={channelUtilizationINT ?? 0}
+>
+  <div class="grow"></div>
+  <div
+    class:bg-green-500={colorClass === 'green'}
+    class:bg-yellow-500={colorClass === 'yellow'}
+    class:bg-orange-500={colorClass === 'orange'}
+    class:bg-red-500={colorClass === 'red'}
+    class:bg-gray-500={colorClass === 'grayscale'}
+    style="height: {scaledHeight}%;"
+  ></div>
+</div>


### PR DESCRIPTION
This is a continuation of discussion and code pull request related to #10 for adding a vertical bar representation of channelUtilization % for each node.  As implemented by these changes, a single-line-height vertical bar is added immediately to the right of the icon of each node, in both smallMode and largeMode.

Hovering over the vertical bar will display either 
- Observed Channel Utilization: XX%
- Channel Utilization Not Reported

The colorization is statically set as follows:
- green for values < 15%
- yellow for values < 25% 
- orange for values < 35%
- red for values >= 35%
- grayscale is the default, and for nodes not reporting channelUtilization

## Screenshots from development environment:

![image](https://github.com/user-attachments/assets/7f5a30c9-4a30-40f1-b6c1-4fb3b65f6519)
![image](https://github.com/user-attachments/assets/d9d82748-d15c-4a32-bf89-88de9ecafb50)


