### PR TITLE
feat: Add dark mode toggle functionality to the map interface #42

### DIFF
--- a/ui/src/Map.svelte
+++ b/ui/src/Map.svelte
@@ -51,6 +51,8 @@
         }
       })
     )
+  
+    ol.renderUserDarkModePref()
   }
 
   let modalPage = 'Settings'

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -89,3 +89,12 @@ button:active {
 .label {
   @apply select-none;
 }
+
+.ol-layers {
+  transition: filter .3s;
+}
+
+.ol-control-darkmode {
+  top: 73px;
+  left: .5em;
+}


### PR DESCRIPTION
As titled #42, image preview as follows

New control button to toggle light/ dark mode, use `localStorage` to store state (string `1/0`).

<img width="1740" alt="image" src="https://github.com/user-attachments/assets/fef41c03-2b5d-40ee-97b6-a5f8fdddc200" />
