### PR TITLE
Update Nodes.svelte added additional visibility toggle

### DIFF
--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -17,17 +17,27 @@
   import { setPositionMode } from './Map.svelte'
   import ChannelUtilization from './lib/ChannelUtilization.svelte'
 
-  export let showInactive = false
+  export let nodeVisibilityMode = 'active'
   let selectedNode: NodeInfo
   export let ol: OpenLayersMap = undefined
 
-  $: $nodes.length, showInactive, $nodeInactiveTimer, filterNodes()
+  $: $nodes.length, $nodeInactiveTimer, filterNodes()
 
   function filterNodes() {
     $inactiveNodes = $nodes.filter((node) => Date.now() - node.lastHeard * 1000 >= ($nodeInactiveTimer ?? 60) * 60 * 1000)
-
     $filteredNodes = $nodes
-      .filter((node) => showInactive || node.num == $myNodeNum || !$inactiveNodes.some((inactive) => node.num == inactive.num))
+      .filter((node) => {
+        switch (nodeVisibilityMode) {
+          case 'active':
+            return node.num === $myNodeNum || !$inactiveNodes.some((inactive) => node.num === inactive.num)
+          case 'inactive':
+            return $inactiveNodes.some((inactive) => node.num === inactive.num)
+          case 'all':
+            return true
+          default:
+            return node.num === $myNodeNum || !$inactiveNodes.some((inactive) => node.num === inactive.num)
+        }
+      })
       .sort((a, b) => {
         if (a.num === $myNodeNum) return -1
         if (b.num === $myNodeNum) return 1
@@ -39,6 +49,35 @@
   function clearNodes() {
     axios.post('/deleteNodes', { nodes: $inactiveNodes })
   }
+
+  // Function to handle node visibility toggle
+  function toggleNodeVisibility() {
+    switch (nodeVisibilityMode) {
+      case 'active':
+        nodeVisibilityMode = 'inactive'
+        break
+      case 'inactive':
+        nodeVisibilityMode = 'all'
+        break
+      case 'all':
+      default:
+        nodeVisibilityMode = 'active'
+        break
+    }
+  }
+
+  // Text mapping for the visibility toggle
+  $: nodeVisibilityText = (() => {
+    const filteredCount = $filteredNodes?.length ?? 0
+    const totalCount = $nodes?.length ?? 0
+    
+    switch (nodeVisibilityMode) {
+      case 'active': return `active ${filteredCount}`
+      case 'inactive': return `inactive ${filteredCount}`
+      case 'all': return `all ${totalCount}`
+      default: return `active ${filteredCount}`
+    }
+  })()
 </script>
 
 <Modal title="Node Detail" visible={selectedNode != undefined}>
@@ -70,13 +109,16 @@
 
 <Card title="Nodes" {...$$restProps}>
   <h2 slot="title" class="rounded-t flex items-center gap-2">
-    <div class="grow">Nodes</div>
-    {#if !$smallMode}
-      <label class="text-sm font-normal"
-        >Inactive
-        <input title="Toggle Inactive Nodes" type="checkbox" bind:checked={showInactive} />
-      </label>
-    {/if}
+    <div class="grow">Nodes
+      {#if !$smallMode}
+        <button 
+          title="Toggle (active/inactive/all) Visibility" 
+          on:click={toggleNodeVisibility} 
+          class="text-sm font-normal ml-1"
+        >
+          ({nodeVisibilityText})
+        </button>
+      {/if}
     <button title="Reduce/Expand Node List" on:click={() => ($smallMode = !$smallMode)} class="btn !px-2 text-sm font-normal">{$smallMode ? '→' : '←'}</button>
   </h2>
   <div class="p-1 text-sm grid gap-1 overflow-auto h-full content-start">


### PR DESCRIPTION
Inactive checkbox replaced with clickable word toggle which rotates display of filteredNodes between active/inactive/all. Modified filterNodes() to reflect these changes. Also now displays the numerical count value of filteredNodes for greater insight into the number of nodes on the observed mesh. Examples:
(active 64)
(inactive 107)
(all 171)

Also changed the button footer text for clearing inactive nodes