### PR TITLE
macOS settings shortcut

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshsense",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshsense",
-      "version": "1.1.0-beta.1",
+      "version": "1.1.0-beta.5",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/electron/src/main/index.ts
+++ b/electron/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, ipcMain, utilityProcess } from 'electron'
+import { app, shell, BrowserWindow, ipcMain, utilityProcess, globalShortcut } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
@@ -136,6 +136,11 @@ app.whenReady().then(async () => {
     // On macOS it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
+
+  globalShortcut.register('CommandOrControl+,', () => {
+    const win = BrowserWindow.getAllWindows()[0]
+    win?.webContents.send('open-settings')
   })
 
   updateCheckLoop()

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -1,8 +1,12 @@
-import { contextBridge } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 
 // Custom APIs for renderer
-const api = {}
+const api = {
+  onOpenSettings: (callback: () => void) => {
+    ipcRenderer.on('open-settings', callback)
+  }
+}
 
 // Use `contextBridge` APIs to expose Electron APIs to
 // renderer only if context isolation is enabled, otherwise

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -36,7 +36,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/intercept-stdout": "^0.1.3",
-        "axios": "^1.7.7",
+        "axios": "^1.8.4",
         "crc": "^4.3.2",
         "dotenv": "^16.4.5",
         "env-paths": "^3.0.0",

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -11,7 +11,7 @@
   import Message from './Message.svelte'
   import { allowRemoteMessaging, connectionStatus, version } from 'api/src/vars'
   import UpdateStatus from './lib/UpdateStatus.svelte'
-  import SettingsModal, { showPage } from './SettingsModal.svelte'
+  import SettingsModal from './SettingsModal.svelte'
   import { hasAccess } from './lib/util'
   import News, { newsVisible } from './News.svelte'
 
@@ -21,6 +21,14 @@
 
 <script lang="ts">
   let ol: OpenLayersMap
+  import { onMount } from 'svelte'
+  import { showPage } from './SettingsModal.svelte'
+
+  onMount(() => {
+    window.api?.onOpenSettings(() => {
+      showPage('Settings')
+    })
+  })
 </script>
 
 <!-- <ServiceWorker /> -->


### PR DESCRIPTION
This adds a shortcut for <kbd>Command</kbd> + <kbd>,</kbd> to open the settings menu which is common on macOS. Minor edit to locks as well since they seemed outdated and were being regenerated locally (let me know if needed to remove that commit).