### PR TITLE
basic macOS menu with shortcuts

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshsense",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshsense",
-      "version": "1.1.0-beta.1",
+      "version": "1.1.0-beta.5",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/electron/src/main/index.ts
+++ b/electron/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { electronApp, optimizer } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { autoUpdater } from 'electron-updater'
+import { buildMenu } from './menu'
 
 let apiProcess: Electron.UtilityProcess
 let apiPort: any = 9999
@@ -138,6 +139,7 @@ app.whenReady().then(async () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
 
+  buildMenu()
   updateCheckLoop()
   // setTimeout(() => {
   //   autoUpdater.quitAndInstall()

--- a/electron/src/main/menu.ts
+++ b/electron/src/main/menu.ts
@@ -1,0 +1,65 @@
+import { app, Menu, BrowserWindow } from 'electron'
+import { autoUpdater } from 'electron-updater'
+
+export function buildMenu() {
+  if (process.platform !== 'darwin') return
+
+  const template: Electron.MenuItemConstructorOptions[] = [
+    {
+      role: 'appMenu',
+      submenu: [
+        {
+          label: 'About',
+          role: 'about'
+        },
+        {
+          label: 'Check for Updates...',
+          click: () => {
+            autoUpdater.checkForUpdates()
+          }
+        },
+        { type: 'separator' },
+        {
+          label: 'Settings...',
+          accelerator: 'CmdOrCtrl+,',
+          click: () => {
+            const win = BrowserWindow.getAllWindows()[0]
+            win?.webContents.send('open-settings')
+          }
+        },
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' }
+      ]
+    },
+    {
+      role: 'fileMenu',
+    },
+    {
+      role: 'editMenu',
+    },
+    {
+      role: 'viewMenu',
+    },
+    {
+      role: 'windowMenu',
+    },
+    {
+      role: 'help',
+      submenu: [
+        {
+          label: 'Version: ' + app.getVersion(),
+
+        }
+      ]
+    }
+  ]
+
+  const menu = Menu.buildFromTemplate(template)
+  Menu.setApplicationMenu(menu)
+}

--- a/electron/src/preload/index.ts
+++ b/electron/src/preload/index.ts
@@ -1,8 +1,12 @@
-import { contextBridge } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 
 // Custom APIs for renderer
-const api = {}
+const api = {
+  onOpenSettings: (callback: () => void) => {
+    ipcRenderer.on('open-settings', callback)
+  }
+}
 
 // Use `contextBridge` APIs to expose Electron APIs to
 // renderer only if context isolation is enabled, otherwise

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -36,7 +36,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/intercept-stdout": "^0.1.3",
-        "axios": "^1.7.7",
+        "axios": "^1.8.4",
         "crc": "^4.3.2",
         "dotenv": "^16.4.5",
         "env-paths": "^3.0.0",

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -11,7 +11,7 @@
   import Message from './Message.svelte'
   import { allowRemoteMessaging, connectionStatus, version } from 'api/src/vars'
   import UpdateStatus from './lib/UpdateStatus.svelte'
-  import SettingsModal, { showPage } from './SettingsModal.svelte'
+  import SettingsModal from './SettingsModal.svelte'
   import { hasAccess } from './lib/util'
   import News, { newsVisible } from './News.svelte'
 
@@ -21,6 +21,15 @@
 
 <script lang="ts">
   let ol: OpenLayersMap
+
+  import { onMount } from 'svelte'
+  import { showPage } from './SettingsModal.svelte'
+
+  onMount(() => {
+     window.api?.onOpenSettings(() => {
+       showPage('Settings')
+     })
+   })
 </script>
 
 <!-- <ServiceWorker /> -->


### PR DESCRIPTION
A basic menu on macOS with support for some general shortcuts. I can try to expand this for Linux and Windows but I would need to set up virtual machines for those as I don't have them local for testing at the moment. Let me know if this isn't acceptable just for macOS.