### PR TITLE
ObservedRF SNR and RSSI upgrades

### DIFF
--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -21,6 +21,7 @@
   import { messageDestination } from './Message.svelte'
   import { setPositionMode } from './Map.svelte'
   import ChannelUtilization from './lib/ChannelUtilization.svelte'
+  import ObservedRF from './lib/ObservedRF.svelte'
 
   export let includeMqtt = (localStorage.getItem('includeMqtt') ?? 'true') == 'true'
   let selectedNode: NodeInfo
@@ -169,16 +170,8 @@
             <button on:click={() => ($messageDestination = node.num)} class="bg-black/20 rounded w-12 text-center overflow-hidden">{node.user?.shortName || '?'}</button>
 
             {#if node.snr && node.hopsAway == 0}
-              <!-- SNR -->
-              <div title="SNR" class="text-sm w-10 shrink-0 text-center {node.snr && node.hopsAway == 0 ? 'bg-black/20' : ''} rounded h-5">
-                {node.snr}
-                <div class="h-0.5 -translate-y-0.5 scale-x-90" style="width: {((node.snr + 20) / 30) * 100}%; background-color: {node.snr >= 0 ? 'green' : node.snr >= -10 ? 'yellow' : 'red'};"></div>
-              </div>
-
-              <!-- RSSI -->
-              <div title="RSSI" class="text-sm w-8 shrink-0 text-center bg-black/20 rounded h-5">
-                {node.rssi || '-'}
-              </div>
+              <!-- display observed RF values for smallMode -->
+              <ObservedRF {node} />
             {:else}
               <!-- Hops -->
               <div title="{node.hopsAway} Hops Away" class="text-sm font-normal bg-black/20 rounded w-10 text-center">{node.num == $myNodeNum ? '-' : (node.hopsAway ?? '?')}</div>
@@ -228,17 +221,9 @@
               <div title="Node heard via MQTT" class="bg-rose-900/50 text-rose-200 rounded px-1 cursor-help text-xs">MQTT</div>
             {/if}
             <div class="grow"></div>
-            <!-- SNR -->
             {#if node.snr && node.hopsAway == 0}
-              <div title="SNR" class="text-sm w-10 shrink-0 text-center {node.snr && node.hopsAway == 0 ? 'bg-black/20' : ''} rounded h-5">
-                {node.snr}
-                <div class="h-0.5 -translate-y-0.5 scale-x-90" style="width: {((node.snr + 20) / 30) * 100}%; background-color: {node.snr >= 0 ? 'green' : node.snr >= -10 ? 'yellow' : 'red'};"></div>
-              </div>
-
-              <!-- RSSI -->
-              <div title="RSSI" class="text-sm w-8 shrink-0 text-center bg-black/20 rounded h-5">
-                {node.rssi || '-'}
-              </div>
+              <!-- display observed RF values -->
+              <ObservedRF {node} />
             {/if}
           </div>
 

--- a/ui/src/lib/ObservedRF.svelte
+++ b/ui/src/lib/ObservedRF.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import type { NodeInfo } from 'api/src/vars'
+  export let node: NodeInfo
+
+  function calculateRFSNRWidthPercentage(snr: number) {
+    // calculate a relative width percentage to represent a bar of SNR values
+
+    const MIN_WIDTH = 15; // Minimum width percentage
+    const MAX_SNR = 10;   // SNR value for 100% width
+    const MIN_SNR = -10;  // SNR value corresponding to minimum width
+    
+    // Limit SNR within our expected range
+    const clampedSNR = Math.max(MIN_SNR, Math.min(MAX_SNR, snr));
+    
+    if (clampedSNR >= MAX_SNR) {
+      return 100; // Maximum width
+    } else {
+      // Linear scale from MIN_WIDTH to 100% based on SNR range
+      // For SNR from -10 to +10, map to width from 10% to 100%
+      const availableRange = 100 - MIN_WIDTH;
+      const snrPosition = (clampedSNR - MIN_SNR) / (MAX_SNR - MIN_SNR);
+      
+      return MIN_WIDTH + (snrPosition * availableRange);
+    }
+  }
+
+  function getRFSNRColor(snr: number) {
+    // determine which color to use for the SNR bar values
+    if (snr >= 4) return 'bg-green-500'
+    if (snr >= 0) return 'bg-[#9acd32]'
+    if (snr >= -3) return 'bg-yellow-500'
+    if (snr >= -6) return 'bg-orange-500'
+    if (snr >= -9) return 'bg-red-500'
+    return 'bg-[red]'
+  }
+</script>
+
+
+              <!-- SNR -->
+              <div title="SNR" class="text-sm w-10 shrink-0 text-center {node.snr && node.hopsAway == 0 ? 'bg-black/20' : ''} rounded h-5">
+                {node.snr}
+                <div  class="h-0.5 -translate-y-0.5 scale-x-90 {getRFSNRColor(node.snr)}" 
+                      style="width: {calculateRFSNRWidthPercentage(node.snr)}%; 
+                             background-color: 'steelblue';"></div>
+              </div>
+
+              <!-- RSSI -->
+              <div title="RSSI" class="text-sm w-8 shrink-0 text-center bg-black/20 rounded h-5">
+                {node.rssi || '-'}
+              </div>


### PR DESCRIPTION
Colorized RF SNR bar width into more granular dynamic threshold ranges, matching the same colors used for battery and channel utilization. This exists for both smallMode and largeMode.

Defines a const for minimum width value.
Ranges are arbitrary but currently set as:
```
    if (snr >= 4) return 'bg-green-500'
    if (snr >= 0) return 'bg-[#9acd32]'
    if (snr >= -3) return 'bg-yellow-500'
    if (snr >= -6) return 'bg-orange-500'
    if (snr >= -9) return 'bg-red-500'
    return 'bg-[red]'
```

![image](https://github.com/user-attachments/assets/3c994c19-332d-4d89-962b-72528927e344)
![image](https://github.com/user-attachments/assets/51fce429-4f92-4021-a7c0-d47edb47551e)
![image](https://github.com/user-attachments/assets/68f8035b-4932-4a3c-98a5-19a185cab1ad)
[yellow would go here but lacking a screenshot example]
![image](https://github.com/user-attachments/assets/f2e6b9c6-fa5f-49fc-a56c-f5cadf5a6ee1)
![image](https://github.com/user-attachments/assets/58d0a875-1ed0-463f-a4b6-52ac1c575a79)
![image](https://github.com/user-attachments/assets/0fd8b4fb-bcd4-48c3-919a-b78c1e9b8364)
![image](https://github.com/user-attachments/assets/a704c714-9034-4905-ba48-e2eed80c7757)
