### PR TITLE
setting to allow highlighting self log entries

### DIFF
--- a/ui/src/Log.svelte
+++ b/ui/src/Log.svelte
@@ -7,6 +7,7 @@
   import OpenLayersMap from './lib/OpenLayersMap.svelte'
   import { tick } from 'svelte'
   import { getSvgUri } from './Map.svelte'
+  import { highlightOwnNode } from './Settings.svelte'
 
   function shouldPacketBeShown(packet: MeshPacket, includeTx, filterText: string) {
     if (filterText) {
@@ -100,7 +101,7 @@
   <div bind:this={packetsDiv} class="p-1 px-2 text-sm overflow-auto grid h-full content-start overflow-x-hidden">
     {#each $packets.filter((p) => shouldPacketBeShown(p, includeTx, filterText)) || [] as packet}
       {#if !messagesOnly || packet.message?.show}
-        <div class="flex gap-2 whitespace-nowrap">
+        <div class="flex gap-2 whitespace-nowrap {($highlightOwnNode && packet.from === $myNodeNum) ? 'text-white/90' : ''}">
           <div class="w-28">{packet.rxTime ? new Date(packet.rxTime * 1000).toLocaleString(undefined, { day: 'numeric', month: 'numeric', hour: 'numeric', minute: 'numeric' }) : ''}</div>
 
           <!-- Nodes -->

--- a/ui/src/Settings.svelte
+++ b/ui/src/Settings.svelte
@@ -2,6 +2,7 @@
   import { entries, get, set } from 'idb-keyval'
   export let updateChannel = new State('updateChannel', undefined)
   export let enableAudioAlerts = writable()
+  export let highlightOwnNode = new State('highlightOwnNode', true)
   get('enableAudioAlerts').then((v) => enableAudioAlerts.set(v ?? true))
   enableAudioAlerts.subscribe((v) => {
     set('enableAudioAlerts', v)
@@ -133,6 +134,11 @@
     <label class="flex gap-2">
       <input type="checkbox" bind:checked={$displayFahrenheit} />
       <div class="font-bold">Display temperature in Fahrenheit</div>
+    </label>
+
+    <label class="flex gap-2">
+      <input type="checkbox" bind:checked={$highlightOwnNode} />
+      <div class="font-bold">Highlight own node's log entries</div>
     </label>
 
     <label class="flex gap-2 items-center">


### PR DESCRIPTION
This adds a setting to highlight entries in the log that come from yourself. It makes it a little easier to pick out lines from your own node vs others.

<img width="587" alt="image" src="https://github.com/user-attachments/assets/4808fec7-5179-4f5c-981e-0ef130bc0f37" />
