### PR TITLE
node bar slimming

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1144,9 +1144,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001713",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
-      "integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
+      "version": "1.0.30001720",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
+      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
       "dev": true,
       "funding": [
         {

--- a/ui/src/Map.svelte
+++ b/ui/src/Map.svelte
@@ -5,7 +5,12 @@
   import { generateHexer } from '@bdancer/icon-gaga'
 
   export function getSvgUri(name: string) {
-    return 'data:image/svg+xml;utf8,' + encodeURIComponent(generateHexer({ name }))
+    const hexId = parseInt(name).toString(16).padStart(8, '0')
+    const colorId = hexId.slice(-6)
+    return 'data:image/svg+xml;utf8,' + encodeURIComponent(generateHexer({ 
+      name,
+      borderColor: `#${colorId}`
+    }))
   }
 
   export function getIconURL(node: NodeInfo) {

--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -118,8 +118,8 @@
             bValue = b.snr || -999
             break
           case 'channelUtilization':
-            aValue = 0
-            bValue = 0
+            aValue = a.deviceMetrics?.channelUtilization || 0
+            bValue = b.deviceMetrics?.channelUtilization || 0
             break
           default:
             aValue = a.lastHeard

--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -164,21 +164,6 @@
     }
   }
 
-  function formatNodeVisibilityText(count: number) {
-    switch ($nodeVisibilityMode) {
-      case 'inactive':
-        return `inactive: ${count}`
-      case 'all':
-        return `all: ${count}`
-      case 'active':
-      default:
-        return `active: ${count}`
-    }
-  }
-
-  // Text mapping for the visibility toggle
-  $: nodeVisibilityText = formatNodeVisibilityText($filteredNodes?.length ?? 0)
-
   function getBatteryColor(batteryLevel) {
     if (batteryLevel === 101) return '' // use HTML style="background-color: 'steelblue'"
     if (batteryLevel >= 70) return 'bg-green-500'
@@ -224,34 +209,44 @@
 <Card title="Nodes" {...$$restProps}>
   <h2 slot="title" class="rounded-t flex items-center gap-2">
     <div class="flex items-center gap-2">
-      Nodes
+      <div class="grow flex items-center gap-2">
+        Nodes
+        {#if !$smallMode}
+          <button
+            title="Toggle Visibility - Currently Showing: {$nodeVisibilityMode}"
+            on:click={toggleNodeVisibility}
+            class="text-xs font-normal ml-1 {
+              $nodeVisibilityMode === 'active' ? 'btn-active' :
+              $nodeVisibilityMode === 'inactive' ? 'btn-inactive' :
+              'btn'
+            }"
+          >
+            {$filteredNodes.length}
+          </button>
+          <select bind:value={$sortField} class="btn text-xs font-normal w-20">
+            <option value="lastHeard">Last Heard</option>
+            <option value="shortName">Short Name</option>
+            <option value="longName">Long Name</option>
+            <option value="batteryLevel">Battery %</option>
+            <option value="batteryVoltage">Voltage</option>
+            <option value="hops">Hops</option>
+            <option value="distance">Distance</option>
+            <option value="rssi">RSSI</option>
+            <option value="snr">SNR</option>
+            <option value="channelUtilization">Channel Util</option>
+          </select>
+          <button title="Toggle Sort Direction" on:click={toggleSortDirection} class="btn text-xs font-normal">
+            {$sortDirection === 'asc' ? '↑' : '↓'}
+          </button>
+        {/if}
+      </div>
       {#if !$smallMode}
-        <button title="Toggle (active/inactive/all) Visibility" on:click={toggleNodeVisibility} class="btn text-xs font-normal ml-1">
-          {nodeVisibilityText}
-        </button>
-        <select bind:value={$sortField} class="btn text-xs font-normal">
-          <option value="lastHeard">Last Heard</option>
-          <option value="shortName">Short Name</option>
-          <option value="longName">Long Name</option>
-          <option value="batteryLevel">Battery %</option>
-          <option value="batteryVoltage">Voltage</option>
-          <option value="hops">Hops</option>
-          <option value="distance">Distance</option>
-          <option value="rssi">RSSI</option>
-          <option value="snr">SNR</option>
-          <option value="channelUtilization">Channel Util</option>
-        </select>
-        <button title="Toggle Sort Direction" on:click={toggleSortDirection} class="btn text-xs font-normal">
-          {$sortDirection === 'asc' ? '↑' : '↓'}
+        <button title="Toggle MQTT Nodes" on:click={() => (includeMqtt = !includeMqtt)} class="text-xs font-normal {includeMqtt ? 'btn' : 'btn-inactive'}">
+          MQTT
         </button>
       {/if}
+      <button title="Reduce/Expand Node List" on:click={() => ($smallMode = !$smallMode)} class="btn !px-2 text-sm font-normal">{$smallMode ? '→' : '←'}</button>
     </div>
-    {#if !$smallMode}
-      <button title="Toggle MQTT Nodes" on:click={() => (includeMqtt = !includeMqtt)} class="text-xs font-normal {includeMqtt ? 'btn' : 'btn-inactive'}">
-        MQTT
-      </button>
-    {/if}
-    <button title="Reduce/Expand Node List" on:click={() => ($smallMode = !$smallMode)} class="btn !px-2 text-sm font-normal">{$smallMode ? '→' : '←'}</button>
   </h2>
   <div>
   {#if !$smallMode}

--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -110,12 +110,22 @@
             }
             break
           case 'rssi':
-            aValue = a.rssi || -999
-            bValue = b.rssi || -999
+            if ((a.hopsAway ?? 0) > 0 || (b.hopsAway ?? 0) > 0) {
+              aValue = a.hopsAway ?? 99
+              bValue = b.hopsAway ?? 99
+            } else {
+              aValue = a.rssi || -999
+              bValue = b.rssi || -999
+            }
             break
           case 'snr':
-            aValue = a.snr || -999
-            bValue = b.snr || -999
+            if ((a.hopsAway ?? 0) > 0 || (b.hopsAway ?? 0) > 0) {
+              aValue = a.hopsAway ?? 99
+              bValue = b.hopsAway ?? 99
+            } else {
+              aValue = a.snr || -999
+              bValue = b.snr || -999
+            }
             break
           case 'channelUtilization':
             aValue = a.deviceMetrics?.channelUtilization || 0

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -74,6 +74,10 @@ h1 {
   @apply px-2 py-0.5 from-blue-800 bg-gradient-to-br to-cyan-700 rounded text-blue-100  border-blue-500;
 }
 
+.btn-inactive {
+  @apply px-2 py-0.5 bg-gray-600/50 rounded text-blue-100 border-blue-500;
+}
+
 button:hover {
   @apply brightness-110;
 }

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -78,6 +78,10 @@ h1 {
   @apply px-2 py-0.5 bg-gray-600/50 rounded text-blue-100 border-blue-500;
 }
 
+.btn-active {
+  @apply px-2 py-0.5 bg-green-500/50 rounded text-blue-100 border-blue-500;
+}
+
 button:hover {
   @apply brightness-110;
 }


### PR DESCRIPTION
Depends on #126 and I can switch base if/when it gets merged.

Two minor things:

* Switch the node visibility to a button that displays the number in the button
* Use the real node color as the icon border (subtle but aligns with meshtastic apps colors)
* Shrinks the sorting dropdown a bit to help keep the existing node sidebar width

<img width="338" alt="image" src="https://github.com/user-attachments/assets/8881b37e-d57a-4e67-828d-4e29355a45c3" />
