### PR TITLE
save electron window size and location and use existing on launch

### DIFF
--- a/electron/src/main/window.ts
+++ b/electron/src/main/window.ts
@@ -1,0 +1,39 @@
+import { BrowserWindow, app } from 'electron'
+import { join } from 'path'
+import { keyFileStorage } from 'key-file-storage'
+
+const userDataPath = app.getPath('userData')
+const windowStateKfs = keyFileStorage(join(userDataPath, 'window-state'))
+
+export interface WindowState {
+  x?: number
+  y?: number
+  width: number
+  height: number
+  isMaximized?: boolean
+}
+
+export function getWindowState(): WindowState {
+  try {
+    const state = windowStateKfs['window-state']
+    return state || { width: 1300, height: 900 }
+  } catch {
+    return { width: 1300, height: 900 }
+  }
+}
+
+export function saveWindowState(window: BrowserWindow): void {
+  try {
+    const bounds = window.getBounds()
+    const state: WindowState = {
+      x: bounds.x,
+      y: bounds.y,
+      width: bounds.width,
+      height: bounds.height,
+      isMaximized: window.isMaximized()
+    }
+    windowStateKfs['window-state'] = state
+  } catch (error) {
+    console.error('[electron] Failed to save window state:', error)
+  }
+}

--- a/electron/tsconfig.node.json
+++ b/electron/tsconfig.node.json
@@ -3,6 +3,7 @@
   "include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*"],
   "compilerOptions": {
     "composite": true,
-    "types": ["electron-vite/node"]
+    "types": ["electron-vite/node"],
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
This saves the window state using the same key-file-storage package that the API had already imported. When the app is reopened it will reuse the state.

```
MeshSense on  ashinn/save-window-state via  v24.1.0 on ☁️  (use2) 
❯ cat ~/Library/Application\ Support/meshsense/window-state/window-state
{
  "x": 190,
  "y": 162,
  "width": 2159,
  "height": 1148,
  "isMaximized": false
}
```