### PR TITLE
feat(ui): :sparkle: Add favorite node visibility option and corresponding styles

### DIFF
--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -58,6 +58,8 @@
             return $inactiveNodes.some((inactive) => node.num === inactive.num)
           case 'all':
             return true
+          case 'favorite':
+            return node.isFavorite === true
           case 'active':
           default:
             return node.num === $myNodeNum || !$inactiveNodes.some((inactive) => node.num === inactive.num)
@@ -163,6 +165,9 @@
         $nodeVisibilityMode = 'inactive'
         break
       case 'inactive':
+        $nodeVisibilityMode = 'favorite'
+        break
+      case 'favorite':
         $nodeVisibilityMode = 'all'
         break
       case 'all':
@@ -226,6 +231,7 @@
             class="text-xs font-normal ml-1 {
               $nodeVisibilityMode === 'active' ? 'btn-active' :
               $nodeVisibilityMode === 'inactive' ? 'btn-inactive' :
+              $nodeVisibilityMode === 'favorite' ? 'btn-favorite' :
               'btn'
             }"
           >

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -82,6 +82,10 @@ h1 {
   @apply px-2 py-0.5 bg-green-500/50 rounded text-blue-100 border-blue-500;
 }
 
+.btn-favorite {
+  @apply px-2 py-0.5 bg-orange-500/50 rounded text-orange-100 border-orange-500;
+}
+
 button:hover {
   @apply brightness-110;
 }


### PR DESCRIPTION
This demo adds a new case `favorite` into the node visibility toggle as proposed in #127.
"Radio Configuration" is not within the scope of this demo.

> Proposed UI
> <img width="1930" height="1826" alt="image" src="https://github.com/user-attachments/assets/d83da097-1f9a-4e3b-b3f1-3f13fb4b9fdb" />
