### PR TITLE
Add `CLIENT_BASE` label to Nodes list for new role

### DIFF
--- a/ui/src/Nodes.svelte
+++ b/ui/src/Nodes.svelte
@@ -333,6 +333,8 @@
                   <div title="TAK Tracker Node" class="bg-indigo-500/50 text-indigo-300 rounded px-1 font-bold cursor-help">TT</div>
                 {:else if node.user.role === 11}
                   <div title="Router_Late Node" class="bg-red-500/50 text-red-200 rounded px-1 font-bold cursor-help">RL</div>
+                {:else if node.user.role === 12}
+                  <div title="Client Base" class="bg-blue-500/50 text-red-200 rounded px-1 font-bold cursor-help">CB</div>
                 {/if}
               {/if}
               {#if node.viaMqtt}


### PR DESCRIPTION
Adds a new label to the Nodes list for the new `CLIENT_BASE` role recently introduced in [v2.7.10.94d4bdf](https://github.com/meshtastic/firmware/releases/tag/v2.7.10.94d4bdf) in https://github.com/meshtastic/firmware/pull/7873

New role ID is based on https://github.com/meshtastic/firmware/blob/develop/src/mesh/generated/meshtastic/config.pb.h#L69-L73

<img width="313" height="60" alt="Screenshot 2025-09-26 at 9 47 41 PM" src="https://github.com/user-attachments/assets/571bc91c-f35d-41de-92c4-5dde20d965e0" />

