### PR TITLE
SendToMeshMap when user details is available

### DIFF
--- a/api/src/meshtastic.ts
+++ b/api/src/meshtastic.ts
@@ -332,7 +332,7 @@ export async function connect(address?: string) {
     let packet: MeshPacket
     packet = packets.upsert({ id: message.id, message })
     let node = getNodeById(packet.from)
-    if (packet?.viaMqtt === false) sendToMeshMap({ num: message.from }, node, packet)
+    if (packet?.viaMqtt === false && node.user) sendToMeshMap({ num: message.from }, node, packet)
   })
 
   /** TELEMETRY_APP */

--- a/api/src/meshtastic.ts
+++ b/api/src/meshtastic.ts
@@ -341,7 +341,7 @@ export async function connect(address?: string) {
     let telemetry = extractPayload(data)
     let packet = packets.upsert({ id, data })
     let node = nodes.upsert({ num: e.from, ...telemetry })
-    if (packet?.viaMqtt === false) sendToMeshMap({ num: e.from, ...telemetry }, node, packet)
+    if (packet?.viaMqtt === false && node.user) sendToMeshMap({ num: e.from, ...telemetry }, node, packet)
   })
 
   /** POSITION_APP */
@@ -351,7 +351,7 @@ export async function connect(address?: string) {
     if (id && data.latitudeI) packet = packets.upsert({ id, data })
     if (e.from && data.latitudeI) {
       let node = nodes.upsert({ num: e.from, position: data })
-      if (packet?.viaMqtt === false) sendToMeshMap({ num: e.from, position: data }, node, packet)
+      if (packet?.viaMqtt === false && node.user) sendToMeshMap({ num: e.from, position: data }, node, packet)
     }
   })
 


### PR DESCRIPTION
When sending to mesh map there are cases where user info in submitted data is required. My patch checks if the user info is available in the cases that I identified.